### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -120,7 +120,7 @@ entries:
         - name: elasticsearch-exporter
           image: docker.io/bitnami/elasticsearch-exporter:1.7.0-debian-12-r11
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r16
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
       licenses: Apache-2.0
     apiVersion: v2
     appVersion: 8.12.2
@@ -487,7 +487,7 @@ entries:
         - name: kubectl
           image: docker.io/bitnami/kubectl:1.30.3-debian-12-r3
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r26
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
       licenses: Apache-2.0
     apiVersion: v2
     appVersion: 3.7.1
@@ -8062,7 +8062,7 @@ entries:
       category: Database
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r30
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
         - name: postgres-exporter
           image: docker.io/bitnami/postgres-exporter:0.15.0-debian-12-r43
         - name: postgresql
@@ -8106,7 +8106,7 @@ entries:
         - name: kubectl
           image: docker.io/bitnami/kubectl:1.30.3-debian-12-r4
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r27
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
         - name: redis
           image: docker.io/openg2p/redis:7.2.5-debian-12-r4
         - name: redis-exporter


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/os-shell:12-debian-12-r16` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r26` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r30` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r27` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)